### PR TITLE
All backward compatible changes: New begin() function without autoScan needed. Added new functions like setFrequencyDivider(). Refactoring using c++ casts. Added const qualifiers. Streamline some functions. Other refactorings.

### DIFF
--- a/examples/testFDC-Serial-OLED/testFDC-Serial-OLED.ino
+++ b/examples/testFDC-Serial-OLED/testFDC-Serial-OLED.ino
@@ -67,12 +67,12 @@ void setup() {
 
   // ### Start FDC
   // Start FDC2212 with 2 channels init
-//  bool capOk = capsense.begin(0x3, 0x4, 0x5, false); //setup first two channels, autoscan with 2 channels, deglitch at 10MHz, external oscillator 
+//  const FDC2214_DEVICE device = capsense.begin(0x3, false, FDC2214_DEGLITCH_10Mhz, false); //setup first two channels, don't stay in sleep mode, deglitch at 10MHz, external oscillator
   // Start FDC2214 with 4 channels init
-  bool capOk = capsense.begin(0xF, 0x6, 0x5, false); //setup all four channels, autoscan with 4 channels, deglitch at 10MHz, external oscillator 
+  const FDC2214_DEVICE device = capsense.begin(0xF, false, FDC2214_DEGLITCH_10Mhz, false); //setup all four channels, don't stay in sleep mode, deglitch at 10MHz, external oscillator
   // Start FDC2214 with 4 channels init
-//  bool capOk = capsense.begin(0xF, 0x6, 0x5, true); //setup all four channels, autoscan with 4 channels, deglitch at 10MHz, internal oscillator 
-  if (capOk) oled.println("Sensor OK");  
+//  const FDC2214_DEVICE device = capsense.begin(0xF, false, FDC2214_DEGLITCH_10Mhz, true); //setup all four channels, don't stay in sleep mode, deglitch at 10MHz, internal oscillator
+  if (device != FDC2214_DEVICE_INVALID) oled.println("Sensor OK");
   else oled.println("Sensor Fail");  
   sensorThreshold[0] = 14000000+320000;
   sensorThreshold[1] = 320000;

--- a/examples/testFDC-Serial/testFDC-Serial.ino
+++ b/examples/testFDC-Serial/testFDC-Serial.ino
@@ -45,12 +45,12 @@ void setup() {
   
   // ### Start FDC
   // Start FDC2212 with 2 channels init
-//  bool capOk = capsense.begin(0x3, 0x4, 0x5, false); //setup first two channels, autoscan with 2 channels, deglitch at 10MHz, external oscillator 
+//  const FDC2214_DEVICE device = capsense.begin(0x3, false, FDC2214_DEGLITCH_10Mhz, false); //setup first two channels, don't stay in sleep mode, deglitch at 10MHz, external oscillator
   // Start FDC2214 with 4 channels init
-  bool capOk = capsense.begin(0xF, 0x6, 0x5, false); //setup all four channels, autoscan with 4 channels, deglitch at 10MHz, external oscillator 
+  const FDC2214_DEVICE device = capsense.begin(0xF, false, FDC2214_DEGLITCH_10Mhz, false); //setup all four channels, don't stay in sleep mode, deglitch at 10MHz, external oscillator
   // Start FDC2214 with 4 channels init
-//  bool capOk = capsense.begin(0xF, 0x6, 0x5, true); //setup all four channels, autoscan with 4 channels, deglitch at 10MHz, internal oscillator 
-  if (capOk) Serial.println("Sensor OK");  
+//  const FDC2214_DEVICE device = capsense.begin(0xF, false, FDC2214_DEGLITCH_10Mhz, true); //setup all four channels, don't stay in sleep mode, deglitch at 10MHz, internal oscillator
+  if (device != FDC2214_DEVICE_INVALID) Serial.println("Sensor OK");
   else Serial.println("Sensor Fail");  
 
 }

--- a/src/FDC2214.cpp
+++ b/src/FDC2214.cpp
@@ -18,6 +18,90 @@
 // Feel free to do whatever you want with it. No licensing BS. No limitations.
 //
 
+#include "FDC2214.h"
+
+//bitmasks
+static constexpr uint16_t FDC2214_CH0_UNREADCONV      = 0x0008;         //denotes unread CH0 reading in STATUS register
+static constexpr uint16_t FDC2214_CH1_UNREADCONV      = 0x0004;         //denotes unread CH1 reading in STATUS register
+static constexpr uint16_t FDC2214_CH2_UNREADCONV      = 0x0002;         //denotes unread CH2 reading in STATUS register
+static constexpr uint16_t FDC2214_CH3_UNREADCONV      = 0x0001;         //denotes unread CH3 reading in STATUS register
+
+static constexpr unsigned FDC2214_OSCILLATOR_SHIFT    = 9;
+static constexpr uint16_t FDC2214_OSCILLATOR_MASK     = 0x1 << FDC2214_OSCILLATOR_SHIFT;
+static constexpr unsigned FDC2214_SLEEP_SHIFT         = 13;
+static constexpr uint16_t FDC2214_SLEEP_MASK          = 0x1 << FDC2214_SLEEP_SHIFT;
+static constexpr uint16_t FDC2214_CLOCK_DIVIDER_MASK  = 0x3FF;
+static constexpr unsigned FDC2214_SENSOR_FREQ_SHIFT   = 12;
+static constexpr uint16_t FDC2214_SENSOR_FREQ_MASK    = 0x3 << FDC2214_SENSOR_FREQ_SHIFT;
+static constexpr unsigned FDC2214_GAIN_SHIFT          = 9;
+static constexpr uint16_t FDC2214_GAIN_MASK           = 0x3 << FDC2214_GAIN_SHIFT;
+
+//registers
+static constexpr uint16_t FDC2214_DEVICE_ID           = 0x7F;
+static constexpr uint16_t FDC2214_MUX_CONFIG          = 0x1B;
+static constexpr uint16_t FDC2214_CONFIG              = 0x1A;
+static constexpr uint16_t FDC2214_RCOUNT_CH0          = 0x08;
+static constexpr uint16_t FDC2214_OFFSET_CH0          = 0x0C;
+static constexpr uint16_t FDC2214_SETTLECOUNT_CH0     = 0x10;
+static constexpr uint16_t FDC2214_CLOCK_DIVIDERS_CH0  = 0x14;
+static constexpr uint16_t FDC2214_STATUS              = 0x18;
+static constexpr uint16_t FDC2214_DATA_CH0_MSB        = 0x00;
+static constexpr uint16_t FDC2214_DATA_CH0_LSB        = 0x01;
+static constexpr uint16_t FDC2214_DRIVE_CH0           = 0x1E;
+static constexpr uint16_t FDC2214_RESET_DEV           = 0x1C;
+
+// mask for 28bit data to filter out flag bits
+static constexpr uint16_t FDC2214_DATA_CHx_MASK_DATA  = 0x0FFF;
+
+static constexpr uint16_t FREQ_DIVIDER_DEFAULT        = 1;
+static constexpr uint16_t SENSOR_FREQ_DEFAULT         = 2;
+
+// index into this array is channel mask minus one
+static const uint8_t AUTOSCAN_EN[] = {
+  0, // msk=0x0001 // SingleChannel Ch0
+  0, // msk=0x0010 // SingleChannel Ch1
+  1, // msk=0x0011
+  0, // msk=0x0100 // SingleChannel Ch2
+  1, // msk=0x0101
+  1, // msk=0x0110
+  1, // msk=0x0111
+  0, // msk=0x1000 // SingleChannel Ch3
+  1, // msk=0x1001
+  1, // msk=0x1010
+  1, // msk=0x1011
+  1, // msk=0x1100
+  1, // msk=0x1101
+  1, // msk=0x1110
+  1, // msk=0x1111
+};
+
+// index into this array is channel mask minus one
+static const uint8_t AUTOSCAN [] = {
+  0x00,  // msk=0x0001 SingleChannel Ch0
+  0x00,  // msk=0x0010 SingleChannel Ch1
+  0x00,  // msk=0x0011 Ch0, Ch1
+  0x01,  // msk=0x0100 SingleChannel Ch2
+  0x01,  // msk=0x0101 Ch0, Ch2 -> Ch0, Ch1, Ch2
+  0x01,  // msk=0x0110 Ch1, Ch2 -> Ch0, Ch1, Ch2
+  0x01,  // msk=0x0111 Ch0, Ch1, Ch2
+  0x10,  // msk=0x1000 SingleChannel Ch3
+  0x10,  // msk=0x1001 Ch0, Ch3 -> Ch0, Ch1, Ch2, Ch3
+  0x10,  // msk=0x1010 Ch1, Ch3 -> Ch0, Ch1, Ch2, Ch3
+  0x10,  // msk=0x1011 Ch0, Ch1, Ch3 -> Ch0, Ch1, Ch2, Ch3
+  0x10,  // msk=0x1100 Ch2, Ch3 -> Ch0, Ch1, Ch2, Ch3
+  0x10,  // msk=0x1101 Ch0, Ch2, Ch3 -> Ch0, Ch1, Ch2, Ch3
+  0x10,  // msk=0x1110 Ch1, Ch2, Ch3 -> Ch0, Ch1, Ch2, Ch3
+  0x10,  // msk=0x1111 Ch0, Ch1, Ch2, Ch3 -> Ch0, Ch1, Ch2, Ch3
+};
+
+// index into this array is channel
+static uint16_t UNREADCONV[] = {
+    FDC2214_CH0_UNREADCONV,
+    FDC2214_CH1_UNREADCONV,
+    FDC2214_CH2_UNREADCONV,
+    FDC2214_CH3_UNREADCONV,
+};
+
 /**************************************************************************/
 /*!
     @file     NelsonsLog_FDC2214.cpp
@@ -32,111 +116,148 @@
     v1.0  - First release
 */
 /**************************************************************************/
-
-#include "Arduino.h"
-#include <Wire.h>
-#include "FDC2214.h"
-
-FDC2214::FDC2214(uint8_t i2caddr) {
-	_i2caddr = i2caddr;
-    //_i2caddr = FDC2214_I2C_ADDRESS;
+static uint16_t channelMaskToChannel(uint8_t chanMask_) {
+  uint16_t result = 0;
+  while(chanMask_ & 1) {
+    result++;
+    chanMask_ >>= 1;
+  }
+  return result;
 }
 
-// Checking for chip ID, if OK, calls chip init
-boolean FDC2214::begin(uint8_t chanMask, uint8_t autoscanSeq, uint8_t deglitchValue, bool intOsc) {
-    Wire.begin();
-
-    int devId = read16FDC(FDC2214_DEVICE_ID);
-    if (devId != 0x3054) {
-        if (devId != 0x3055) {
-            //two valid device ids for FDC2214 0x3054 and 0x3055
-            return false;
-        }
-    }
-
-    loadSettings(chanMask, autoscanSeq, deglitchValue, intOsc);
-//    setGain();
-
-    return true;
+FDC2214::FDC2214(FDC2214_I2C_ADDR i2caddr, typeof(Wire)& wire) : _i2caddr(i2caddr), _wire(wire), _device(FDC2214_DEVICE_INVALID) {
 }
 
+const FDC2214_DEVICE FDC2214::readDeviceId() const {
+  const uint32_t device = read16FDC(FDC2214_DEVICE_ID);
+  switch(device) {
+    case FDC2214_DEVICE_FDC211x:
+    case FDC2214_DEVICE_FDC221x:
+      return static_cast<FDC2214_DEVICE>(device);
+  }
+  return FDC2214_DEVICE_INVALID;
+}
+
+const FDC2214_DEVICE FDC2214::getDevice() const {
+  if (_device == FDC2214_DEVICE_INVALID) {
+    _device = readDeviceId();
+  }
+  return _device;
+}
+
+const size_t FDC2214::getChannelCount() const {
+  switch (getDevice()) {
+    case FDC2214_DEVICE_FDC211x:
+    return 2;
+  case FDC2214_DEVICE_FDC221x:
+    return 4;
+  }
+  return 0;
+}
+
+bool FDC2214::begin(uint8_t channelMask, uint8_t deglitchValue, uint8_t, bool useInternalOscillator) {
+  _wire.begin();
+  const FDC2214_DEVICE device = getDevice();
+  const bool bOk = (device != FDC2214_DEVICE_INVALID);
+  if (bOk) {
+    loadSettings(channelMask, false, deglitchValue, useInternalOscillator, FDC2214_GAIN_1);
+  }
+  return bOk;
+}
+
+FDC2214_DEVICE FDC2214::begin(uint8_t chanMask, bool enableSleepMode, FDC2214_DEGLITCH deglitchValue, bool useInternalOscillator, FDC2214_GAIN gain) {
+  _wire.begin();
+  const FDC2214_DEVICE device = getDevice();
+  const bool bOk = (device != FDC2214_DEVICE_INVALID);
+  if (bOk) {
+    loadSettings(chanMask, enableSleepMode, deglitchValue, useInternalOscillator, gain);
+    return device;
+  }
+  return FDC2214_DEVICE_INVALID;
+}
+
+void FDC2214::loadChannelSettings(const uint16_t regOffset) {
+  //settle count maximized, slow application
+  write16FDC(FDC2214_SETTLECOUNT_CH0 + regOffset, 0x64);
+  //rcount maximized for highest accuracy
+  write16FDC(FDC2214_RCOUNT_CH0 + regOffset, 0xFFFF);
+  //no offset
+  write16FDC(FDC2214_OFFSET_CH0 + regOffset, 0x0000);
+
+  // Set clock dividers
+  //  Reserved
+  //  | Sensor Frequency Select. b01 = /1 = sensor freq 0.01 to 8.75MHz; b10 = /2 = sensor freq 0.01 to 10 or 5 to 10 MHz
+  //  | | Reserved
+  //  | | |         Reference divider. Must be > 1. fref = fclk / this register`
+  //  | | |         |
+  // 00FF00RRRRRRRRRR -> 0010000000000001 -> 0x2001
+  uint16_t clockRegister = read16FDC(FDC2214_CLOCK_DIVIDERS_CH0 + regOffset);
+  clockRegister &= FDC2214_SENSOR_FREQ_MASK;
+  clockRegister |= SENSOR_FREQ_DEFAULT << FDC2214_SENSOR_FREQ_SHIFT;
+
+  // Set divider to default, if not set yet.
+  if((clockRegister & FDC2214_CLOCK_DIVIDER_MASK) == 0) {
+    clockRegister |= FREQ_DIVIDER_DEFAULT;
+  }
+
+  write16FDC(FDC2214_CLOCK_DIVIDERS_CH0 + regOffset, clockRegister);
+
+  //set drive register
+  write16FDC(FDC2214_DRIVE_CH0 + regOffset, 0xF800);
+}
 
 //Internal routine to do actual chip init
-void FDC2214::loadSettings(uint8_t chanMask, uint8_t autoscanSeq, uint8_t deglitchValue, bool intOsc) {
+void FDC2214::loadSettings(uint8_t chanMask, bool enableSleepMode, uint8_t deglitchValue, bool useInternalOscillator, FDC2214_GAIN gain) {
 
 	//Configuration register
 	//	Active channel Select: b00 = ch0; b01 = ch1; b10 = ch2; b11 = ch3;
 	//  |Sleep Mode: 0 - device active; 1 - device in sleep;
 	//  ||Reserved, reserved, set to 1
-	//  |||Sensor Activation Mode: 0 - drive sensor with full current. 1 - drive sensor with current set by DRIVE_CURRENT_CHn 
+	//  |||Sensor Activation Mode: 0 - drive sensor with full current. 1 - drive sensor with current set by DRIVE_CURRENT_CHn
 	//  ||||Reserved, set to 1
 	//  |||||Reference clock: 0 - use internal; 1 - use external clock
 	//  ||||||Reserved, set to 0
 	//  |||||||Disable interrupt. 0 - interrupt output on INTB pin; 1 - no interrupt output
 	//  ||||||||High current sensor mode: 0 - 1.5mA max. 1 - > 1.5mA, not available if Autoscan is enabled
-	//  |||||||||      Reserved, set to 000001
-	//  |||||||||      |
-	//  CCS1A1R0IH000000 -> 0001 1110 1000 0001 -> 0x1E81 	ExtOsc
-	//  CCS1A1R0IH000000 -> 0001 1100 1000 0001 -> 0x1C81	IntOsc
-	if (intOsc) {
-		write16FDC(FDC2214_CONFIG, 0x1C81);  //set config
-	} else {
-		write16FDC(FDC2214_CONFIG, 0x1E81);  //set config
-	}
-	//If channel 1 selected, init it..
-	if (chanMask & 0x01) {
+	//  |||||||||Reserved, set to 000001
+	//  ||||||||||
+	// CCS1A1R0IH000001 -> 0001 1110 1000 0001 -> 0x1E81 	ExtOsc
+	// CCS1A1R0IH000001 -> 0001 1100 1000 0001 -> 0x1C81	IntOsc
 
-		//settle count maximized, slow application
-		write16FDC(FDC2214_SETTLECOUNT_CH0, 0x64);
+  const uint8_t chanMask_(chanMask & 0x0f);
+  const uint16_t autoScanEn = AUTOSCAN_EN[chanMask_-1];
 
-		//rcount maximized for highest accuracy
-		write16FDC(FDC2214_RCOUNT_CH0, 0xFFFF);
+  {
+    const uint16_t singleScanChan = autoScanEn ? 0 : channelMaskToChannel(chanMask_);
+    const uint16_t config = 0x1C81 | singleScanChan |
+      (static_cast<uint16_t>(not useInternalOscillator) << FDC2214_OSCILLATOR_SHIFT) |
+      (static_cast<uint16_t>(enableSleepMode) << FDC2214_SLEEP_SHIFT);
+    write16FDC(FDC2214_CONFIG, config);  //set config
+  }
 
-		//no offset
-		write16FDC(FDC2214_OFFSET_CH0, 0x0000);
-		
-		// Set clock dividers
-		//  Reserved
-		//  | Sensor Frequency Select. b01 = /1 = sensor freq 0.01 to 8.75MHz; b10 = /2 = sensor freq 0.01 to 10 or 5 to 10 MHz
-		//  | | Reserved
-		//  | | |         Reference divider. Must be > 1. fref = fclk / this register`
-		//  | | |         |
-		// 00FF00RRRRRRRRRR -> 0010000000000001 -> 0x2001
-		write16FDC(FDC2214_CLOCK_DIVIDERS_CH0, 0x2001);
-		//set drive register
-		write16FDC(FDC2214_DRIVE_CH0, 0xF800);
-	}
-	// Init chan2, if selected by channel init mask
-	if (chanMask & 0x02) {
-		write16FDC(FDC2214_SETTLECOUNT_CH1, 0x64);
-		write16FDC(FDC2214_RCOUNT_CH1, 0xFFFF);
-		write16FDC(FDC2214_OFFSET_CH1, 0x0000);
-		write16FDC(FDC2214_CLOCK_DIVIDERS_CH1, 0x2001);
-		write16FDC(FDC2214_DRIVE_CH1, 0xF800);	
-	}	
-	if (chanMask & 0x04) {
-		write16FDC(FDC2214_SETTLECOUNT_CH2, 0x64);
-		write16FDC(FDC2214_RCOUNT_CH2, 0xFFFF);
-		write16FDC(FDC2214_OFFSET_CH2, 0x0000);
-		write16FDC(FDC2214_CLOCK_DIVIDERS_CH2, 0x2001);
-		write16FDC(FDC2214_DRIVE_CH2, 0xF800);	
-	}	
-	if (chanMask & 0x08) {
-		write16FDC(FDC2214_SETTLECOUNT_CH3, 0x64);
-		write16FDC(FDC2214_RCOUNT_CH3, 0xFFFF);
-		write16FDC(FDC2214_OFFSET_CH3, 0x0000);
-		write16FDC(FDC2214_CLOCK_DIVIDERS_CH3, 0x2001);
-		write16FDC(FDC2214_DRIVE_CH3, 0xF800);	
-	}	
+  {
+    uint16_t resetDev = read16FDC(FDC2214_RESET_DEV);
+    resetDev &= ~FDC2214_GAIN_MASK;
+    resetDev |= static_cast<uint16_t>(gain) << FDC2214_GAIN_SHIFT;
+    write16FDC(FDC2214_RESET_DEV, resetDev);
+  }
+
+  for(size_t c = 0; c < getChannelCount(); c++) {
+    //If channel c selected, init it..
+    if (chanMask & (0x01 << c)) {
+      loadChannelSettings(c);
+    }
+  }
+
 	// Autoscan: 0 = single channel, selected by CONFIG.ACTIVE_CHAN
 	// | Autoscan sequence. b00 for chan 1-2, b01 for chan 1-2-3, b10 for chan 1-2-3-4
 	// | |         Reserved - must be b0001000001
 	// | |         |  Deglitch frequency. b001 for 1 MHz, b100 for 3.3 MHz, b101 for 10 Mhz, b111 for 33 MHz
 	// | |         |  |
-    // ARR0001000001DDD -> b0000 0010 0000 1000 -> h0208
-	uint16_t muxVal = 0x0208 | ((uint16_t)autoscanSeq << 13) | deglitchValue;
+  // ARR0001000001DDD -> b0000 0010 0000 1000 -> h0208
+	const uint16_t muxVal = 0x0208 | (autoScanEn << 15) | (static_cast<uint16_t>(AUTOSCAN[chanMask_-1]) << 13) | deglitchValue;
 	//
-    write16FDC(FDC2214_MUX_CONFIG, muxVal);  //set mux config for channels
+  write16FDC(FDC2214_MUX_CONFIG, muxVal);  //set mux config for channels
 }
 
 ///**************************************************************************/
@@ -183,130 +304,145 @@ void FDC2214::loadSettings(uint8_t chanMask, uint8_t autoscanSeq, uint8_t deglit
 //}
 
 
-
 // Gets 28bit reading for FDC2212 and FDC2214
 // Takes in channel number, gives out the formatted 28 bit reading.
-unsigned long FDC2214::getReading28(uint8_t channel) {
-    int timeout = 100;
+unsigned long FDC2214::getReading28(uint8_t channel, int timeout) const {
+  if(channel < getChannelCount()) {
+    const uint8_t addressLSB = FDC2214_DATA_CH0_LSB + 2*channel + 1;
+    const uint8_t addressMSB = FDC2214_DATA_CH0_MSB + 2*channel;
+    const uint16_t bitUnreadConv = UNREADCONV[channel];
+
+    uint16_t status = read16FDC(FDC2214_STATUS);
     unsigned long reading = 0;
-    int status = read16FDC(FDC2214_STATUS);
-    uint8_t addressMSB;
-	uint8_t addressLSB;
-	uint8_t bitUnreadConv;
-	switch (channel){
-		case (0):
-			addressMSB = FDC2214_DATA_CH0_MSB;
-			addressLSB = FDC2214_DATA_CH0_LSB;
-			bitUnreadConv = FDC2214_CH0_UNREADCONV;
-		break;
-		case (1):
-			addressMSB = FDC2214_DATA_CH1_MSB;
-			addressLSB = FDC2214_DATA_CH1_LSB;
-			bitUnreadConv = FDC2214_CH1_UNREADCONV;
-		break;
-		case (2):
-			addressMSB = FDC2214_DATA_CH2_MSB;
-			addressLSB = FDC2214_DATA_CH2_LSB;
-			bitUnreadConv = FDC2214_CH2_UNREADCONV;
-		break;
-		case (3):
-			addressMSB = FDC2214_DATA_CH3_MSB;
-			addressLSB = FDC2214_DATA_CH3_LSB;
-			bitUnreadConv = FDC2214_CH3_UNREADCONV;
-		break;
-		default: return 0;
-	}
-	
-	while (timeout && !(status & bitUnreadConv)) {
-        status = read16FDC(FDC2214_STATUS);
-        timeout--;
+
+    while (timeout && !(status & bitUnreadConv)) {
+          status = read16FDC(FDC2214_STATUS);
+          timeout--;
     }
+
     if (timeout == 100) {
-// #####################################################################################################
-// There was this weird double read, as "first readout could be stale" in Nelsons file. 
-// I have not confirmed the existence of this silicon bug.
-// I suspect that it might be due to crappy breadboard or rats nest wiring or lack of signal integrity for other reason
-// 
-// On the other hand, I have done far too little testing to be sure, so I am leaving that bit in for now.
-//	
-// #####################################################################################################
-		//could be stale grab another //could it really it? ?????
-        //read the 28 bit result
-        reading = (uint32_t)(read16FDC(addressMSB) & FDC2214_DATA_CHx_MASK_DATA) << 16;
-        reading |= read16FDC(addressLSB);
-        while (timeout && !(status & bitUnreadConv)) {
-            status = read16FDC(FDC2214_STATUS);
-            timeout--;
-        }
+      // #####################################################################################################
+      // There was this weird double read, as "first readout could be stale" in Nelsons file.
+      // I have not confirmed the existence of this silicon bug.
+      // I suspect that it might be due to crappy breadboard or rats nest wiring or lack of signal integrity for other reason
+      //
+      // On the other hand, I have done far too little testing to be sure, so I am leaving that bit in for now.
+      //
+      // #####################################################################################################
+
+      //could be stale grab another //could it really it? ?????
+      //read the 28 bit result
+      reading = static_cast<unsigned long>(read16FDC(addressMSB) & FDC2214_DATA_CHx_MASK_DATA) << 16;
+      reading |= read16FDC(addressLSB);
+      while (timeout && !(status & bitUnreadConv)) {
+          status = read16FDC(FDC2214_STATUS);
+          timeout--;
+      }
     }
     if (timeout) {
-        //read the 28 bit result
-        reading = (uint32_t)(read16FDC(addressMSB) & FDC2214_DATA_CHx_MASK_DATA) << 16;
-        reading |= read16FDC(addressLSB);
-        return reading;
+      //read the 28 bit result
+      reading = static_cast<unsigned long>(read16FDC(addressMSB) & FDC2214_DATA_CHx_MASK_DATA) << 16;
+      reading |= read16FDC(addressLSB);
+      return reading;
     } else {
-		// Could not get data, chip readynes flag timeout
-        return 0;
+      // Could not get data, chip readynes flag timeout
     }
+  }
+  return 0;
 }
 
 // Gets 16bit reading for FDC2112 and FDC2114
 // Takes in channel number, gives out the formatted 28 bit reading.
-unsigned long FDC2214::getReading16(uint8_t channel) {
-    int timeout = 100;
+unsigned long FDC2214::getReading16(uint8_t channel, int timeout) const {
+  if(channel < getChannelCount()) {
+    const uint8_t addressMSB = FDC2214_DATA_CH0_MSB + 2*channel;
+    const uint16_t bitUnreadConv = UNREADCONV[channel];
+
+    uint16_t status = read16FDC(FDC2214_STATUS);
     unsigned long reading = 0;
-    int status = read16FDC(FDC2214_STATUS);
-    uint8_t addressMSB;
-	uint8_t bitUnreadConv;
-	switch (channel){
-		case (0):
-			addressMSB = FDC2214_DATA_CH0_MSB;
-			bitUnreadConv = FDC2214_CH0_UNREADCONV;
-		break;
-		case (1):
-			addressMSB = FDC2214_DATA_CH1_MSB;
-			bitUnreadConv = FDC2214_CH1_UNREADCONV;
-		break;
-		case (2):
-			addressMSB = FDC2214_DATA_CH2_MSB;
-			bitUnreadConv = FDC2214_CH2_UNREADCONV;
-		break;
-		case (3):
-			addressMSB = FDC2214_DATA_CH3_MSB;
-			bitUnreadConv = FDC2214_CH3_UNREADCONV;
-		break;
-		default: return 0;
-	}
-	
-	while (timeout && !(status & bitUnreadConv)) {
-        status = read16FDC(FDC2214_STATUS);
-        timeout--;
+
+    while (timeout && !(status & bitUnreadConv)) {
+      status = read16FDC(FDC2214_STATUS);
+      timeout--;
     }
     if (timeout == 100) {
-// #####################################################################################################
-// There was this weird double read, as "first readout could be stale" in Nelsons file. 
-// I have not confirmed the existence of this silicon bug.
-// I suspect that it might be due to crappy breadboard or rats nest wiring or lack of signal integrity for other reason
-// 
-// On the other hand, I have done far too little testing to be sure, so I am leaving that bit in for now.
-//	
-// #####################################################################################################
-		//could be stale grab another //could it really it? ?????
-        //read the 28 bit result
-        reading = (uint32_t)(read16FDC(addressMSB) & FDC2214_DATA_CHx_MASK_DATA) << 16;
-        while (timeout && !(status & bitUnreadConv)) {
-            status = read16FDC(FDC2214_STATUS);
-            timeout--;
-        }
+      // #####################################################################################################
+      // There was this weird double read, as "first readout could be stale" in Nelsons file.
+      // I have not confirmed the existence of this silicon bug.
+      // I suspect that it might be due to crappy breadboard or rats nest wiring or lack of signal integrity for other reason
+      //
+      // On the other hand, I have done far too little testing to be sure, so I am leaving that bit in for now.
+      //
+      // #####################################################################################################
+
+      //could be stale grab another //could it really it? ?????
+      //read the 28 bit result
+      reading = static_cast<unsigned long>((read16FDC(addressMSB) & FDC2214_DATA_CHx_MASK_DATA)) << 16;
+      while (timeout && !(status & bitUnreadConv)) {
+        status = read16FDC(FDC2214_STATUS);
+        timeout--;
+      }
     }
     if (timeout) {
-        //read the 16 bit result
-        reading = (uint32_t)(read16FDC(addressMSB) & FDC2214_DATA_CHx_MASK_DATA) << 16;
-        return reading;
+      //read the 16 bit result
+      reading = static_cast<unsigned long>(read16FDC(addressMSB) & FDC2214_DATA_CHx_MASK_DATA) << 16;
+      return reading;
     } else {
-		// Could not get data, chip readynes flag timeout
-		return 0;
+      // Could not get data, chip readyness flag timeout
     }
+  }
+  return 0;
+}
+
+bool FDC2214::setOffset(uint8_t channel, uint16_t value) {
+  if(channel < getChannelCount()) {
+    write16FDC(FDC2214_OFFSET_CH0 + channel, value);
+    return true;
+  }
+  return false;
+}
+
+bool FDC2214::setFrequencyDivider(uint8_t channel, uint16_t value) {
+  if(channel < 4) {
+    if(value > 0 && value <= FDC2214_CLOCK_DIVIDER_MASK) {
+      const bool sleepModeAlreadyEnabled = enableSleepMode();
+      uint16_t clockDivider = read16FDC(FDC2214_CLOCK_DIVIDERS_CH0 + channel);
+      clockDivider &= ~FDC2214_CLOCK_DIVIDER_MASK;
+      clockDivider |= value;
+      write16FDC(FDC2214_CLOCK_DIVIDERS_CH0 + channel, clockDivider);
+      if(not sleepModeAlreadyEnabled) {
+        disableSleepMode();
+      }
+    }
+  }
+  return false;
+}
+
+bool FDC2214::isSleepModeEnabled()const {
+  const uint16_t config = read16FDC(FDC2214_CONFIG);
+  return (config & FDC2214_SLEEP_MASK) != 0;
+}
+
+bool FDC2214::enableSleepMode() {
+  uint16_t config = read16FDC(FDC2214_CONFIG);
+  if((config & FDC2214_SLEEP_MASK) != 0) {
+    // Already enabled.
+    return true;
+  }
+  config |= FDC2214_SLEEP_MASK;
+  write16FDC(FDC2214_CONFIG, config);
+  return false;
+}
+
+bool FDC2214::disableSleepMode() {
+  uint16_t config = read16FDC(FDC2214_CONFIG);
+  if((config & FDC2214_SLEEP_MASK) == 0) {
+    // Already disabled.
+    return false;
+  }
+  config &= ~FDC2214_SLEEP_MASK;
+  write16FDC(FDC2214_CONFIG, config);
+  return true;
 }
 
 ///**************************************************************************/
@@ -337,47 +473,56 @@ unsigned long FDC2214::getReading16(uint8_t channel) {
 //    }
 //}
 
-
-/**************************************************************************/
-/*!
-    @brief  Scans various gain settings until the amplitude flag is cleared.
-            WARNING: Changing the gain setting will generally have an impact on the
-            reading.
-*/
-/**************************************************************************/
-//void NelsonsLog_FDC2214::setGain(void) {
-//    //todo
-//}
 /**************************************************************************/
 /*!
     @brief  I2C low level interfacing
 */
 /**************************************************************************/
 
-// Read 2 bytes from the FDC at 'address'
-uint16_t FDC2214::read16FDC(uint16_t address) {
-    uint16_t data = 0;
 
-    Wire.beginTransmission(_i2caddr);
-    Wire.write(address);
-    Wire.endTransmission(false); //restart
+// Read 1 byte from the FDC at 'address'
+uint8_t FDC2214::read8FDC(uint16_t address) const {
+    _wire.beginTransmission(_i2caddr);
+    _wire.write(address >> 8);
+    _wire.write(address);
+    _wire.endTransmission(false);
+    _wire.requestFrom(_i2caddr, (uint8_t) 1);
+    const uint8_t r = _wire.read();
+    return r;
+}
 
-    Wire.requestFrom(_i2caddr, (uint8_t) 2);
+// Read 2 byte from the FDC at 'address'
+uint16_t FDC2214::read16FDC(uint16_t address) const {
 
-    if (Wire.available() == 2) {
-        data = Wire.read();
-        data <<= 8;
-        data |= Wire.read();
-    }
+    _wire.beginTransmission(_i2caddr);
+//    _wire.write(address >> 8);
+    _wire.write(address);
+    _wire.endTransmission(false); //restart
 
+    _wire.requestFrom(_i2caddr, 2);
+    while (!_wire.available());
+    uint16_t data = _wire.read();
+    data <<= 8;
+    while (!_wire.available());
+    data |= _wire.read();
+    _wire.endTransmission(true); //end
     return data;
+}
+
+// write 1 byte to FDC
+void FDC2214::write8FDC(uint16_t address, uint8_t data) {
+    _wire.beginTransmission(_i2caddr);
+    _wire.write(address >> 8);
+    _wire.write(address);
+    _wire.write(data);
+    _wire.endTransmission();
 }
 
 // write 2 bytes to FDC  
 void FDC2214::write16FDC(uint16_t address, uint16_t data) {
-    Wire.beginTransmission(_i2caddr);
-    Wire.write(address & 0xFF);
-    Wire.write(data >> 8);
-    Wire.write(data);
-    Wire.endTransmission();
+    _wire.beginTransmission(_i2caddr);
+    _wire.write(address & 0xFF);
+    _wire.write(data >> 8);
+    _wire.write(data);
+    _wire.endTransmission();
 }


### PR DESCRIPTION
Replaced tabs by spaces so that indents appear the same way in any editor.
Removed defines that don't need to be part of API from .h file to .cpp file.
Changed defines to constexpr for better type safety. Changed _i2caddr variable and constructor parameter to enum to be more type safe.
Initialize member variable in constructor initializer list rather than function body.
Use const where possible.
Automatically calculate auto scan value and auto scan enable from channel mask. Remove autoscanSeq from begin() function. Keep old begin() function for backward compatibility reasons.
Add freqency divider as parameter to new begin() function. Avoid uninitialized variables by defining them as late as possible. Removed unused variables.
Removed obsolete cast operators.
getReading28 and getReading16 timeout becomes parameter with default value 100.
Constructor now taking the Wire object to use.
Refactored loadSettings.
Added enableSleepMode().
Added disableSleepMode().
Added isSleepModeEnabled().
Added setFrequencyDivider().
Only set frequency divider to 1 in loadSettings() function, if frequency divider is 0. Otherwise, the divider value is kept. Added parameter enableSleepMode with default set to false in begin() function.
Removed obsolete variables.
Pass gain as additional parameter to begin() and loadSettings(). Set gain in loadSettings().
Removed definition of WIRE_WRITE, because it is nowhere used. Removed include of Wire.h instead of Arduino.h in FDC2214.h. Include "FDC2214.h" in FCD2214.cpp.
Removed definition of PortReg and PortMask, because it isn't used anywhere.

Introduced public function getDevice().
begin() function return type is now FDC2214_DEVICE. Streamlined getReading16() and getReading28().
Removed read32FDC() because it isn't used anywhere. Added getChannelCount().

Removed todo NelsonsLog_FDC2214::setGain(), because gain can be passed in begin() function.